### PR TITLE
Add support for the rest of the EventEmitter member functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,10 +5,21 @@ interface StringKeyedObject {
 }
 
 export interface TypeSafeEventEmitter<C extends StringKeyedObject> extends EventEmitter {
-
   // K has to be a key on C (the passed type) but it also has to be a string and then we use index
   // types to get the actual type that we expect (C[K]).
 
-  emit<K extends Extract<keyof C, string>>(k: K, v: C[K]): boolean 
-  on<K extends Extract<keyof C, string>>(k: K, f:(v: C[K]) => void): this 
+  addListener<K extends Extract<keyof C, string>>(eventName: K, listener: (arg: C[K]) => void): this
+  on<K extends Extract<keyof C, string>>(eventName: K, listener: (arg: C[K]) => void): this
+  once<K extends Extract<keyof C, string>>(eventName: K, listener: (arg: C[K]) => void): this
+  removeListener<K extends Extract<keyof C, string>>(eventName: K, listener: (arg: C[K]) => void): this
+  off<K extends Extract<keyof C, string>>(eventName: K, listener: (arg: C[K]) => void): this
+  removeAllListeners<K extends Extract<keyof C, string>>(eventName?: K): this
+  setMaxListeners(n: number): this
+  getMaxListeners(): number
+  listeners<K extends Extract<keyof C, string>>(eventName: K): Function[]
+  rawListeners<K extends Extract<keyof C, string>>(eventName: K): Function[]
+  emit<K extends Extract<keyof C, string>>(eventName: K, arg: C[K]): boolean
+  listenerCount<K extends Extract<keyof C, string>>(eventName: K): number
+  prependListener<K extends Extract<keyof C, string>>(eventName: K, listener: (arg: C[K]) => void): this
+  prependOnceListener<K extends Extract<keyof C, string>>(eventName: K, listener: (arg: C[K]) => void): this
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typesafe-event-emitter",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Typescript declarations for making event emitters type safe",
   "main": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
You did a great job, why stop at `on()` and `emit()`?